### PR TITLE
Use logging so hdc-py output appears promptly in CI

### DIFF
--- a/src/hdc_py/hdc.py
+++ b/src/hdc_py/hdc.py
@@ -1,4 +1,6 @@
 import hashlib
+import io
+import logging
 import os
 import pathlib
 import platform
@@ -18,6 +20,39 @@ from typing import Any, Literal, Optional
 
 
 _HASH_BUFFER_SIZE = 1024 * 1024
+
+logger = logging.getLogger(__name__)
+
+
+def _enable_line_buffered_stdio() -> None:
+    """Line-buffer stdout/stderr when they are not TTYs so CI sees logs promptly."""
+    for stream in (sys.stdout, sys.stderr):
+        if stream is None:
+            continue
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            if stream.isatty():
+                continue
+            reconfigure(line_buffering=True)
+        except (OSError, ValueError, io.UnsupportedOperation):
+            continue
+
+
+def _install_default_handler() -> None:
+    """Log to stderr. StreamHandler flushes after each record."""
+    if logger.handlers:
+        return
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+
+_enable_line_buffered_stdio()
+_install_default_handler()
 
 
 def _is_wsl() -> bool:
@@ -120,7 +155,7 @@ class Hdc:
         try:
             self._run(["wait"], timeout=timeout)
         except subprocess.TimeoutExpired as e:
-            print(f"Failed to find hdc device in {timeout} seconds", file=sys.stderr)
+            logger.warning("Failed to find hdc device in %s seconds", timeout)
             raise e
 
     def list_targets(self) -> list[str]:
@@ -198,7 +233,7 @@ class HarmonyDevice:
 
     def cmd(self, command: str, **kwargs) -> CompletedProcess:  # noqa: ANN003
         check = kwargs.pop("check", True)
-        print(f"Executing hdc command on {self.target}: {command}", file=sys.stderr)
+        logger.info("Executing hdc command on %s: %s", self.target, command)
 
         exit_code_file = self._device_temp_path("hdc-py-exit-code")
         quoted_exit_code_file = shlex.quote(exit_code_file)
@@ -532,4 +567,4 @@ class HarmonyDevicePerfMode:
             self.hdc.cmd("power-shell setmode 600")
             self.hdc.cmd("power-shell timeout -r")
         except Exception as e:
-            print(f"Warning: Failed to restore power-shell settings: {e}", file=sys.stderr)
+            logger.warning("Failed to restore power-shell settings: %s", e)

--- a/tests/test_hdc.py
+++ b/tests/test_hdc.py
@@ -1,4 +1,6 @@
+import logging
 import os
+import sys
 from pathlib import Path
 import shlex
 import subprocess
@@ -16,6 +18,7 @@ from hdc_py import (
     HarmonyDeviceConnector,
     HarmonyDevicePerfMode,
 )
+from hdc_py import hdc as hdc_module
 
 
 REMOTE_TMP_DIR = "/data/local/tmp/hdc-py-tests"
@@ -67,6 +70,63 @@ def _fake_device(tmp_path: Path, command_handler: str, target: str = "fake-targe
     )
     fake_hdc.chmod(0o755)
     return HarmonyDevice(Hdc(hdc_path=fake_hdc), target)
+
+
+def test_enable_line_buffered_stdio_on_non_tty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    output_path = tmp_path / "stdio.txt"
+    with output_path.open("w", buffering=-1) as stream:
+        assert stream.line_buffering is False
+        monkeypatch.setattr(hdc_module.sys, "stdout", stream)
+        monkeypatch.setattr(hdc_module.sys, "stderr", stream)
+        hdc_module._enable_line_buffered_stdio()
+        assert stream.line_buffering is True
+
+
+def test_hdc_logger_uses_flushing_stderr_handler() -> None:
+    handlers = [handler for handler in hdc_module.logger.handlers if isinstance(handler, logging.StreamHandler)]
+    assert handlers
+    assert any(handler.stream is sys.stderr for handler in handlers)
+    assert hdc_module.logger.level <= logging.INFO
+
+
+def test_hdc_logger_flushes_each_record() -> None:
+    read_fd, write_fd = os.pipe()
+    writer = os.fdopen(write_fd, "w")
+    reader = os.fdopen(read_fd, "r")
+    handler = logging.StreamHandler(writer)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    hdc_module.logger.addHandler(handler)
+    try:
+        os.set_blocking(read_fd, False)
+        hdc_module.logger.info("ci-visible")
+        try:
+            output = reader.read()
+        except BlockingIOError:
+            output = ""
+        assert "ci-visible" in output
+    finally:
+        hdc_module.logger.removeHandler(handler)
+        writer.close()
+        reader.close()
+
+
+def test_wait_logs_when_no_device_is_found(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    fake_hdc = tmp_path / "fake-hdc"
+    fake_hdc.write_text("#!/bin/sh\nexec sleep 30\n", encoding="utf-8")
+    fake_hdc.chmod(0o755)
+    hdc = Hdc(hdc_path=fake_hdc)
+    with caplog.at_level(logging.WARNING, logger=hdc_module.logger.name):
+        with pytest.raises(subprocess.TimeoutExpired):
+            hdc.wait(timeout=0.2)
+    assert "Failed to find hdc device in 0.2 seconds" in caplog.text
+
+
+def test_cmd_logs_the_device_command(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    device = _fake_device(tmp_path, "exit 0")
+    with caplog.at_level(logging.INFO, logger=hdc_module.logger.name):
+        with pytest.raises(RuntimeError, match="Could not read device exit code"):
+            device.cmd("echo hi", capture_output=True, text=True)
+    assert "Executing hdc command on fake-target: echo hi" in caplog.text
 
 
 def test_hdc_resolves_hdc_binary() -> None:


### PR DESCRIPTION
Fixes #25

Python block-buffers stdout in CI, so hdc-py `print()` output shows up late. Switch to the logging module (stderr StreamHandler flushes each record) and line-buffer stdio when not a TTY.

Device-free tests cover buffering, flush, and log paths.

Signed-off-by: Tony Coder <407243179@qq.com>